### PR TITLE
Feature/Add support for elasticsearch self-signed certificates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,13 +2,14 @@
 #
 # @api private
 class cerebro::config (
-  $secret              = $cerebro::secret,
-  $hosts               = $cerebro::hosts,
-  $basepath            = $cerebro::basepath,
-  $java_home           = $cerebro::java_home,
-  $java_opts           = $cerebro::java_opts,
-  $basic_auth_settings = $cerebro::basic_auth_settings,
-  $sysconfig           = $cerebro::sysconfig,
+  $secret                 = $cerebro::secret,
+  $hosts                  = $cerebro::hosts,
+  $basepath               = $cerebro::basepath,
+  $java_home              = $cerebro::java_home,
+  $java_opts              = $cerebro::java_opts,
+  $basic_auth_settings    = $cerebro::basic_auth_settings,
+  $sysconfig              = $cerebro::sysconfig,
+  $accept_any_certificate = $cerebro::accept_any_certificate,
 ) {
   file { '/etc/cerebro/application.conf':
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@
 #  Defines basic authentication settings.
 # @param address
 #  Defines the IP address cerebro should listen on.
+# @param accept_any_certificate
+#  Determines if we accept or deny self-signed certificates
 class cerebro (
   Stdlib::Ensure::Service $service_ensure = $cerebro::params::service_ensure,
   Boolean          $service_enable = $cerebro::params::service_enable,
@@ -56,6 +58,7 @@ class cerebro (
   Optional[Stdlib::Unixpath] $java_home  = $cerebro::params::java_home,
   Optional[Hash] $basic_auth_settings    = $cerebro::params::basic_auth_settings,
   Optional[Stdlib::IP::Address] $address = $cerebro::params::address,
+  Boolean        $accept_any_certificate = $cerebro::params::accept_any_certificate,
 ) inherits cerebro::params {
   contain cerebro::user
   contain cerebro::install

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,4 +27,5 @@ class cerebro::params {
     'Debian' => '/etc/default/cerebro',
     default  => '/etc/sysconfig/cerebro',
   }
+  $accept_any_certificate = false
 }

--- a/templates/etc/cerebro/application.conf.erb
+++ b/templates/etc/cerebro/application.conf.erb
@@ -21,3 +21,6 @@ hosts = [
   },
 <% end -%>
 ]
+<% if @accept_any_certificate == true -%>
+play.ws.ssl.loose.acceptAnyCertificate = true
+<% end -%>


### PR DESCRIPTION
When I'm trying to connect to ES instances with self-signed certificates, cerebro behaves as if it could not connect to endpoint, with a SSL certificat error in logs : `[ConnectException: General SSLEngine problem]`

The PR implements a fix that address this issue : https://github.com/lmenezes/cerebro/issues/127

The nominal behaviour is **not allowing "any certificate"** (as currently). Thus to enable it user must set `$cerebro::accept_any_certificate` at "true".

